### PR TITLE
Tweak CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+
+# Ignore the following errors:
+#   E402: "module level import not at top of file"
+#   E731: "do not assign a lambda expression, use a def"
+#   E133: "closing bracket is missing indentation"
+#   E123: "closing bracket does not match indentation of opening bracket's line"
+#   -> Disable flake8 forcing us to decide on both PEP8-compliant styles on
+#      putting the closing bracket. If I had to choose, I'd probaby set
+#      `hang-closing` to True.
+ignore = E123,E133,E402,E731
+
+exclude = .git
+
+# Despite of this rather relaxed line length limitation set here,
+# contributors are strongly encouraged to adhere to an 80 character limit.
+max-line-length = 95

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
     - python --version
     - uname -a
     - pytest -vv test/
+    - bash audit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# Instruct Travis to build PRs ass well as merges
+# to master. See https://stackoverflow.com/a/31882307/145400.
+branches:
+  only:
+    - master
+
 os:
   - linux
 #  - osx

--- a/audit.sh
+++ b/audit.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-echo ">>> Run gipc unit tests, investigate code coverage ..."
-cd test && py.test --cov-report term --cov-report html --cov gipc
-cd ..
-echo -e "\n>>> Run setup.py check..."
+set -ex
 python setup.py check
-echo -e "\n>>> Run python setup.py --long-description | rst2html.py > /dev/null ..."
 python setup.py --long-description | rst2html.py > /dev/null
-echo -e "\n>>> Run rst2html.py CHANGELOG.rst > /dev/null ..."
 rst2html.py CHANGELOG.rst > /dev/null
-echo -e "\n>>> Run PEP8 check ..."
-pep8
-echo -e "\n>>> Run pylint on gipc/gipc.py ..."
-pylint --reports=n --disable=C0103,W0212,W0511,W0142,R0903 gipc/gipc.py
+
+# Run flake8 on the gipc directory (do not yet
+# run on examples and test code).
+flake8 gipc/
+
+# The pylint result is not to be interpreted in a binary fashion.
+# pylint --reports=n --disable=C0103,W0212,W0511,W0142,R0903 gipc/gipc.py

--- a/gipc/__init__.py
+++ b/gipc/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2012-2015 Jan-Philip Gehrcke. See LICENSE file for details.
+# flake8: noqa
 
 
 __version__ = '0.6.0'

--- a/gipc/gipc.py
+++ b/gipc/gipc.py
@@ -27,15 +27,17 @@ import logging
 import multiprocessing
 import multiprocessing.process
 from itertools import chain
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
+
 WINDOWS = sys.platform == "win32"
+
 if WINDOWS:
     import multiprocessing.reduction
     import msvcrt
-
 
 import gevent
 import gevent.os
@@ -504,9 +506,12 @@ class _GProcess(multiprocessing.Process):
                 status = 'stopped'
             elif isinstance(status, int):
                 status = 'stopped[%s]' % exitcodedict.get(status, status)
-            return '<%s(%s, %s%s)>' % (type(self).__name__, self._name,
-                status, self.daemon and ' daemon' or '')
-
+            return '<%s(%s, %s%s)>' % (
+                type(self).__name__,
+                self._name,
+                status,
+                self.daemon and ' daemon' or ''
+                )
 
     def join(self, timeout=None):
         """
@@ -899,13 +904,13 @@ class _GIPCWriter(_GIPCHandle):
     def _write_py26_fallback(self, bindata):
         # memoryview() is not available in Python 2.6, buffer() has been
         # removed from Python 3. The API of buffer/memview objects differs.
-        bindata = buffer(bindata)
+        bindata = buffer(bindata)  # noqa: F821
         while True:
             bytes_written = _write_nonblocking(self._fd, bindata)
             if len(bindata) == bytes_written:
                 break
             # Get new buffer with `bytes_written` offset of previous buffer.
-            bindata = buffer(bindata, bytes_written)
+            bindata = buffer(bindata, bytes_written)  # noqa: F821
 
     def put(self, o):
         """Encode object ``o`` and write it to the pipe.
@@ -948,11 +953,14 @@ class _PairContext(tuple):
         exit exception.
         """
         e2_exit_exception = None
+
         try:
             self[1].__exit__(exc_type, exc_value, traceback)
-        except:
+        except:  # noqa: E722
             e2_exit_exception = sys.exc_info()
+
         self[0].__exit__(exc_type, exc_value, traceback)
+
         if e2_exit_exception:
             _reraise(*e2_exit_exception)
 
@@ -1030,7 +1038,8 @@ def _set_all_handles(handles):
 
 # Inspect signal module for signals whose action is to be restored to the
 # default action right after fork.
-_signals_to_reset = [getattr(signal, s) for s in
+_signals_to_reset = [
+    getattr(signal, s) for s in
     set([s for s in dir(signal) if s.startswith("SIG")]) -
     # Exclude constants that are not signals such as SIG_DFL and SIG_BLOCK.
     set([s for s in dir(signal) if s.startswith("SIG_")]) -

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,2 +1,4 @@
 pytest==3.2.3
 pytest-cov==2.5.1
+rst2html5
+flake8


### PR DESCRIPTION
This modernizes `audit.sh` and makes Travis execute it as part of the CI. In particular, this PR
- replaces `pep8` in `audit.sh` with `flake8`, and adds a corresponding configuration file
- outcomments the pylint command in `audit.sh`, because this was never supposed to deliver a binary result.