### PR TITLE
flake8: address W503/W504

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,8 @@
 #   -> Disable flake8 forcing us to decide on both PEP8-compliant styles on
 #      putting the closing bracket. If I had to choose, I'd probaby set
 #      `hang-closing` to True.
-ignore = E123,E133,E402,E731
+#   W503: either W504 or W503 must be ignored since flake8 3.6.0
+ignore = E123,E133,E402,E731,W503
 
 exclude = .git
 

--- a/gipc/gipc.py
+++ b/gipc/gipc.py
@@ -1099,11 +1099,11 @@ def _set_all_handles(handles):
 # default action right after fork.
 _signals_to_reset = [
     getattr(signal, s) for s in
-    set([s for s in dir(signal) if s.startswith("SIG")]) -
+    set([s for s in dir(signal) if s.startswith("SIG")])
     # Exclude constants that are not signals such as SIG_DFL and SIG_BLOCK.
-    set([s for s in dir(signal) if s.startswith("SIG_")]) -
+    - set([s for s in dir(signal) if s.startswith("SIG_")])
     # Leave handlers for SIG(STOP/KILL/PIPE) untouched.
-    set(['SIGSTOP', 'SIGKILL', 'SIGPIPE'])]
+    - set(['SIGSTOP', 'SIGKILL', 'SIGPIPE'])]
 
 
 def _reset_signal_handlers():

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,4 +3,4 @@ pytest-cov==2.6.0
 sphinx==1.8.1
 sphinx-rtd-theme==0.4.1
 rst2html5
-flake8
+flake8==3.6.0


### PR DESCRIPTION
Address flake8 error after update to flake8 release 3.6.0. Pin flake8. Related discussion: https://gitlab.com/pycqa/flake8/issues/466