### PR TITLE
LICENSE: update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The files belonging to gipc are released under the following MIT license:
+The MIT License
 
-Copyright 2012-2017 Jan-Philip Gehrcke (http://gehrcke.de)
+Copyright (c) 2012-2018 Dr. Jan-Philip Gehrcke (https://gehrcke.de)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ at jgehrcke@googlemail.com or use the `GitHub issue tracker
 Author & license
 ================
 gipc is written and maintained by `Jan-Philip Gehrcke <https://gehrcke.de>`_.
-It is licensed under an MIT license (see LICENSE file).
+It is licensed under the MIT license (see LICENSE file).
 
 I am thankful for all contributions (bug reports, code, great questions) from:
 


### PR DESCRIPTION
Also change the wording of the first line to clarify that this is _the_ MIT license, and not "some MIT" license.