### PR TITLE
bump gevent to 21.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
         "Topic :: System :: Hardware :: Symmetric Multi-processing",
         "Intended Audience :: Developers",
     ],
-    install_requires=("gevent>=1.5,<=21.1"),
+    install_requires=("gevent>=1.5,<=21.1.2"),
 )


### PR DESCRIPTION
gevent 21.1.2 been released since Jan, and I'm depending on it already on one of my projects
```
  Because no versions of gipc match >1.2.0,<2.0.0
   and gipc (1.2.0) depends on gevent (>=1.5,<=21.1), gipc (>=1.2.0,<2.0.0) requires gevent (>=1.5,<=21.1).
  And because js-ng (11.0b13) depends on gevent (21.1.2), g
```
Hope this fixes it if tests pass